### PR TITLE
ResultError - Add safe versions of 'ToErrorString()' and 'ToErrorStru…

### DIFF
--- a/src/Futurum.Core/Result/ResultError.cs
+++ b/src/Futurum.Core/Result/ResultError.cs
@@ -8,7 +8,12 @@ namespace Futurum.Core.Result;
 public interface IResultError
 {
     /// <summary>
-    /// Get Error as <see cref="ResultErrorStructure"/> 
+    /// Get Error as <see cref="ResultErrorStructure"/>. Sensitive information (e.g. StackTraces) are not included 
+    /// </summary>
+    ResultErrorStructure GetErrorStructureSafe();
+    
+    /// <summary>
+    /// Get Error as <see cref="ResultErrorStructure"/>
     /// </summary>
     ResultErrorStructure GetErrorStructure();
 }
@@ -19,7 +24,12 @@ public interface IResultError
 public interface IResultErrorNonComposite : IResultError
 {
     /// <summary>
-    /// Get Error as <see cref="string"/> 
+    /// Get Error as <see cref="string"/>. Sensitive information (e.g. StackTraces) are not included
+    /// </summary>
+    string GetErrorStringSafe();
+    
+    /// <summary>
+    /// Get Error as <see cref="string"/>
     /// </summary>
     string GetErrorString();
 }
@@ -30,7 +40,12 @@ public interface IResultErrorNonComposite : IResultError
 public interface IResultErrorComposite : IResultError
 {
     /// <summary>
-    /// Get Error as <see cref="string"/> 
+    /// Get Error as <see cref="string"/>. Sensitive information (e.g. StackTraces) are not included
+    /// </summary>
+    string GetErrorStringSafe(string seperator);
+    
+    /// <summary>
+    /// Get Error as <see cref="string"/>
     /// </summary>
     string GetErrorString(string seperator);
     

--- a/src/Futurum.Core/Result/ResultErrorComposite.cs
+++ b/src/Futurum.Core/Result/ResultErrorComposite.cs
@@ -29,6 +29,24 @@ public class ResultErrorComposite : IResultErrorComposite
     public IEnumerable<IResultError> Children { get; }
 
     /// <inheritdoc />
+    public string GetErrorStringSafe(string seperator)
+    {
+        string Transform(IResultError resultError) =>
+            resultError.ToErrorStringSafe(seperator);
+
+        string GetChildrenErrorString() =>
+            Children.Select(Transform)
+                    .StringJoin(seperator);
+
+        string GetParentErrorString() =>
+            Parent.Value.GetErrorStringSafe();
+
+        return Parent.HasValue
+            ? $"{GetParentErrorString()}{seperator}{GetChildrenErrorString()}"
+            : GetChildrenErrorString();
+    }
+
+    /// <inheritdoc />
     public string GetErrorString(string seperator)
     {
         string Transform(IResultError resultError) =>
@@ -45,6 +63,12 @@ public class ResultErrorComposite : IResultErrorComposite
             ? $"{GetParentErrorString()}{seperator}{GetChildrenErrorString()}"
             : GetChildrenErrorString();
     }
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructureSafe() =>
+        Parent.HasValue
+            ? ResultErrorStructureExtensions.ToResultErrorStructure(Parent.Value.GetErrorStringSafe(), Children.Select(ResultErrorStructureExtensions.ToErrorStructureSafe))
+            : ResultErrorStructureExtensions.ToResultErrorStructure(Children.Select(ResultErrorStructureExtensions.ToErrorStructureSafe));
 
     /// <inheritdoc />
     public ResultErrorStructure GetErrorStructure() =>

--- a/src/Futurum.Core/Result/ResultErrorEmpty.cs
+++ b/src/Futurum.Core/Result/ResultErrorEmpty.cs
@@ -9,10 +9,16 @@ public class ResultErrorEmpty : IResultErrorNonComposite
     }
 
     /// <inheritdoc />
-    public string GetErrorString() =>
+    public string GetErrorStringSafe() =>
         string.Empty;
 
+    public string GetErrorString() =>
+        GetErrorStringSafe();
+
     /// <inheritdoc />
-    public ResultErrorStructure GetErrorStructure() =>
+    public ResultErrorStructure GetErrorStructureSafe() =>
         ResultErrorStructureExtensions.CreateEmptyResultErrorStructure();
+
+    public ResultErrorStructure GetErrorStructure() =>
+        GetErrorStructureSafe();
 }

--- a/src/Futurum.Core/Result/ResultErrorException.cs
+++ b/src/Futurum.Core/Result/ResultErrorException.cs
@@ -13,10 +13,18 @@ public class ResultErrorException : IResultErrorNonComposite
     public Exception Exception { get; }
 
     /// <inheritdoc />
-    public string GetErrorString() =>
+    public string GetErrorStringSafe() =>
         Exception.Message;
 
     /// <inheritdoc />
-    public ResultErrorStructure GetErrorStructure() =>
+    public string GetErrorString() =>
+        Exception.ToString();
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructureSafe() =>
         Exception.Message.ToResultErrorStructure();
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructure() =>
+        Exception.ToString().ToResultErrorStructure();
 }

--- a/src/Futurum.Core/Result/ResultErrorKeyNotFound.cs
+++ b/src/Futurum.Core/Result/ResultErrorKeyNotFound.cs
@@ -15,12 +15,20 @@ public class ResultErrorKeyNotFound : IResultErrorNonComposite
     }
 
     /// <inheritdoc />
-    public string GetErrorString() =>
+    public string GetErrorStringSafe() =>
         $"Unable to find key : '{_key}' in source : '{_sourceDescription}'";
 
     /// <inheritdoc />
+    public string GetErrorString() =>
+        GetErrorStringSafe();
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructureSafe() =>
+        new(GetErrorStringSafe(), Enumerable.Empty<ResultErrorStructure>());
+
+    /// <inheritdoc />
     public ResultErrorStructure GetErrorStructure() =>
-        new(GetErrorString(), Enumerable.Empty<ResultErrorStructure>());
+        GetErrorStructureSafe();
 
     /// <summary>
     /// Create a <see cref="ResultErrorKeyNotFound"/> 

--- a/src/Futurum.Core/Result/ResultErrorMessage.cs
+++ b/src/Futurum.Core/Result/ResultErrorMessage.cs
@@ -13,10 +13,18 @@ public class ResultErrorMessage : IResultErrorNonComposite
     public string Message { get; }
 
     /// <inheritdoc />
-    public string GetErrorString() =>
+    public string GetErrorStringSafe() =>
         Message;
 
     /// <inheritdoc />
-    public ResultErrorStructure GetErrorStructure() =>
+    public string GetErrorString() =>
+        GetErrorStringSafe();
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructureSafe() =>
         Message.ToResultErrorStructure();
+
+    /// <inheritdoc />
+    public ResultErrorStructure GetErrorStructure() =>
+        GetErrorStructureSafe();
 }

--- a/src/Futurum.Core/Result/ResultErrorStringExtensions.cs
+++ b/src/Futurum.Core/Result/ResultErrorStringExtensions.cs
@@ -6,10 +6,28 @@ namespace Futurum.Core.Result;
 public static class ResultErrorStringExtensions
 {
     /// <summary>
+    /// Transforms an <see cref="IResultError"/> into a <see cref="string"/>. Sensitive information (e.g. StackTraces) are not included
+    /// </summary>
+    public static string ToErrorStringSafe(this IResultError error) =>
+        ToErrorStringSafe(error, ";");
+
+    /// <summary>
     /// Transforms an <see cref="IResultError"/> into a <see cref="string"/>
     /// </summary>
     public static string ToErrorString(this IResultError error) =>
         ToErrorString(error, ";");
+
+    /// <summary>
+    /// Transforms an <see cref="IResultError"/> into a <see cref="string"/>. Sensitive information (e.g. StackTraces) are not included
+    /// </summary>
+    public static string ToErrorStringSafe(this IResultError resultError, string seperator) =>
+        resultError switch
+        {
+            null                                             => string.Empty,
+            IResultErrorNonComposite resultErrorNonComposite => resultErrorNonComposite.GetErrorStringSafe(),
+            IResultErrorComposite resultErrorComposite       => resultErrorComposite.GetErrorStringSafe(seperator),
+            _                                                => $"Unknown ResultError of type {resultError.GetType().FullName}. '{resultError.ToString()}'"
+        };
 
     /// <summary>
     /// Transforms an <see cref="IResultError"/> into a <see cref="string"/>

--- a/src/Futurum.Core/Result/ResultErrorStructureExtensions.cs
+++ b/src/Futurum.Core/Result/ResultErrorStructureExtensions.cs
@@ -6,6 +6,16 @@ namespace Futurum.Core.Result;
 public static class ResultErrorStructureExtensions
 {
     /// <summary>
+    /// Transforms an <see cref="IResultError"/> into a <see cref="ResultErrorStructure"/>. Sensitive information (e.g. StackTraces) are not included
+    /// </summary>
+    public static ResultErrorStructure ToErrorStructureSafe(this IResultError resultError) =>
+        resultError switch
+        {
+            null => CreateEmptyResultErrorStructure(),
+            _    => resultError.GetErrorStructureSafe()
+        };
+
+    /// <summary>
     /// Transforms an <see cref="IResultError"/> into a <see cref="ResultErrorStructure"/>
     /// </summary>
     public static ResultErrorStructure ToErrorStructure(this IResultError resultError) =>

--- a/test/Futurum.Core.Tests/Helper/Result/FluentAssertionResultExtensions.cs
+++ b/test/Futurum.Core.Tests/Helper/Result/FluentAssertionResultExtensions.cs
@@ -166,6 +166,16 @@ public static class FluentAssertionResultExtensions
     /// <summary>
     /// Specifies that the <see cref="Futurum.Core.Result.Result"/> should be <see cref="Futurum.Core.Result.Result.IsFailure"/> true with <paramref name="errorMessages"/>.
     /// </summary>
+    public static void ShouldBeFailureWithErrorSafe(this Core.Result.Result result, params string[] errorMessages)
+    {
+        result.ShouldBeFailure();
+
+        result.Error.Map(ResultErrorStringExtensions.ToErrorStringSafe).Should().Be(string.Join(";", errorMessages));
+    }
+
+    /// <summary>
+    /// Specifies that the <see cref="Futurum.Core.Result.Result"/> should be <see cref="Futurum.Core.Result.Result.IsFailure"/> true with <paramref name="errorMessages"/>.
+    /// </summary>
     public static void ShouldBeFailureWithError(this Core.Result.Result result, params string[] errorMessages)
     {
         result.ShouldBeFailure();
@@ -181,6 +191,15 @@ public static class FluentAssertionResultExtensions
         result.IsFailure.Should().BeTrue();
     }
 
+    /// <summary>
+    /// Specifies that the <see cref="Futurum.Core.Result.Result{T}"/> should be <see cref="Futurum.Core.Result.Result{T}.IsFailure"/> true with <paramref name="errorMessages"/>.
+    /// </summary>
+    public static void ShouldBeFailureWithErrorSafe<T>(this Result<T> result, params string[] errorMessages)
+    {
+        result.ShouldBeFailure();
+
+        result.Error.Map(ResultErrorStringExtensions.ToErrorStringSafe).Should().Be(string.Join(";", errorMessages));
+    }
     /// <summary>
     /// Specifies that the <see cref="Futurum.Core.Result.Result{T}"/> should be <see cref="Futurum.Core.Result.Result{T}.IsFailure"/> true with <paramref name="errorMessages"/>.
     /// </summary>

--- a/test/Futurum.Core.Tests/Result/ResultErrorCompositeTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorCompositeTests.cs
@@ -12,11 +12,29 @@ namespace Futurum.Core.Tests.Result;
 public class ResultErrorCompositeTests
 {
     [Fact]
+    public void ToErrorStringSafe()
+    {
+        var exceptionErrorMessage = Guid.NewGuid().ToString();
+
+        var resultErrorException = ThrowException(exceptionErrorMessage).ToResultError();
+
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultErrorMessage = errorMessage.ToResultError();
+
+        var resultError = ResultErrorCompositeExtensions.ToResultError(resultErrorMessage, resultErrorException);
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be($"{errorMessage},{exceptionErrorMessage}");
+    }
+
+    [Fact]
     public void ToErrorString()
     {
         var exceptionErrorMessage = Guid.NewGuid().ToString();
 
-        var resultErrorException = new Exception(exceptionErrorMessage).ToResultError();
+        var resultErrorException = ThrowException(exceptionErrorMessage).ToResultError();
 
         var errorMessage = Guid.NewGuid().ToString();
 
@@ -26,7 +44,35 @@ public class ResultErrorCompositeTests
 
         var errorString = resultError.ToErrorString(",");
 
-        errorString.Should().Be($"{errorMessage},{exceptionErrorMessage}");
+        var expectedExceptionErrorMessage = @$"System.Exception: {exceptionErrorMessage}
+   at Futurum.Core.Tests.Result.ResultErrorCompositeTests.ThrowException(String errorMessage) in";
+        errorString.Should().StartWith($"{errorMessage},{expectedExceptionErrorMessage}");
+        errorString.Should().EndWith(@$"test/Futurum.Core.Tests/Result/ResultErrorCompositeTests.cs:line 110");
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var exceptionErrorMessage = Guid.NewGuid().ToString();
+
+        var resultErrorException = ThrowException(exceptionErrorMessage).ToResultError();
+
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultErrorMessage = errorMessage.ToResultError();
+
+        var resultError = ResultErrorCompositeExtensions.ToResultError(resultErrorMessage, resultErrorException);
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        var parentErrorMessage = errorStructure.Message;
+        parentErrorMessage.Should().Be(errorMessage);
+        
+        var childErrors = errorStructure.Children.ToList();
+        childErrors.Count.Should().Be(1);
+
+        childErrors[0].Message.Should().Be(exceptionErrorMessage);
+        childErrors[0].Children.Should().BeEmpty();
     }
 
     [Fact]
@@ -34,7 +80,7 @@ public class ResultErrorCompositeTests
     {
         var exceptionErrorMessage = Guid.NewGuid().ToString();
 
-        var resultErrorException = new Exception(exceptionErrorMessage).ToResultError();
+        var resultErrorException = ThrowException(exceptionErrorMessage).ToResultError();
 
         var errorMessage = Guid.NewGuid().ToString();
 
@@ -49,8 +95,23 @@ public class ResultErrorCompositeTests
         
         var childErrors = errorStructure.Children.ToList();
         childErrors.Count.Should().Be(1);
-
-        childErrors[0].Message.Should().Be(exceptionErrorMessage);
+        
+        var expectedExceptionErrorMessage = @$"System.Exception: {exceptionErrorMessage}
+   at Futurum.Core.Tests.Result.ResultErrorCompositeTests.ThrowException(String errorMessage) in";
+        childErrors[0].Message.Should().StartWith(expectedExceptionErrorMessage);
+        childErrors[0].Message.Should().EndWith($@"test/Futurum.Core.Tests/Result/ResultErrorCompositeTests.cs:line 110");
         childErrors[0].Children.Should().BeEmpty();
+    }
+
+    private Exception ThrowException(string? errorMessage)
+    {
+        try
+        {
+            throw new Exception(errorMessage);
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
     }
 }

--- a/test/Futurum.Core.Tests/Result/ResultErrorCustomTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorCustomTests.cs
@@ -20,11 +20,29 @@ public class ResultErrorCustomTests
             _message = message;
         }
 
-        public string GetErrorString() =>
+        public string GetErrorStringSafe() =>
             _message;
 
-        public ResultErrorStructure GetErrorStructure() =>
+        public string GetErrorString() =>
+            GetErrorStringSafe();
+
+        public ResultErrorStructure GetErrorStructureSafe() =>
             new(_message, Enumerable.Empty<ResultErrorStructure>());
+
+        public ResultErrorStructure GetErrorStructure() =>
+            GetErrorStructureSafe();
+    }
+
+    [Fact]
+    public void ToErrorStringSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultError = new TestResultError(errorMessage);
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -37,6 +55,19 @@ public class ResultErrorCustomTests
         var errorString = resultError.ToErrorString(",");
 
         errorString.Should().Be(errorMessage);
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultError = new TestResultError(errorMessage);
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        errorStructure.Message.Should().Be(errorMessage);
+        errorStructure.Children.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Futurum.Core.Tests/Result/ResultErrorEmptyTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorEmptyTests.cs
@@ -9,6 +9,18 @@ namespace Futurum.Core.Tests.Result;
 public class ResultErrorEmptyTests
 {
     [Fact]
+    public void ToErrorStringSafe()
+    {
+        var errorMessage = string.Empty;
+
+        var resultError = errorMessage.ToResultError();
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be(string.Empty);
+    }
+
+    [Fact]
     public void ToErrorString()
     {
         var errorMessage = string.Empty;
@@ -18,6 +30,19 @@ public class ResultErrorEmptyTests
         var errorString = resultError.ToErrorString(",");
 
         errorString.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var errorMessage = string.Empty;
+
+        var resultError = errorMessage.ToResultError();
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        errorStructure.Message.Should().BeEmpty();
+        errorStructure.Children.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Futurum.Core.Tests/Result/ResultErrorExceptionTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorExceptionTests.cs
@@ -11,17 +11,48 @@ namespace Futurum.Core.Tests.Result;
 public class ResultErrorExceptionTests
 {
     [Fact]
+    public void ToErrorStringSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var exception = ThrowException(errorMessage);
+
+        var resultError = exception.ToResultError();
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be(errorMessage);
+    }
+
+    [Fact]
     public void ToErrorString()
     {
         var errorMessage = Guid.NewGuid().ToString();
 
-        var exception = new Exception(errorMessage);
+        var exception = ThrowException(errorMessage);
 
         var resultError = exception.ToResultError();
 
         var errorString = resultError.ToErrorString(",");
 
-        errorString.Should().Be(errorMessage);
+        errorString.Should().StartWith(@$"System.Exception: {errorMessage}
+   at Futurum.Core.Tests.Result.ResultErrorExceptionTests.ThrowException(String errorMessage) in");
+        errorString.Should().EndWith(@$"test/Futurum.Core.Tests/Result/ResultErrorExceptionTests.cs:line 79");
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var exception = ThrowException(errorMessage);
+
+        var resultError = exception.ToResultError();
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        errorStructure.Message.Should().Be(errorMessage);
+        errorStructure.Children.Should().BeEmpty();
     }
 
     [Fact]
@@ -29,13 +60,27 @@ public class ResultErrorExceptionTests
     {
         var errorMessage = Guid.NewGuid().ToString();
 
-        var exception = new Exception(errorMessage);
+        var exception = ThrowException(errorMessage);
 
         var resultError = exception.ToResultError();
 
         var errorStructure = resultError.ToErrorStructure();
-
-        errorStructure.Message.Should().Be(errorMessage);
+       
+        errorStructure.Message.Should().StartWith(@$"System.Exception: {errorMessage}
+   at Futurum.Core.Tests.Result.ResultErrorExceptionTests.ThrowException(String errorMessage) in");
+        errorStructure.Message.Should().EndWith(@$"test/Futurum.Core.Tests/Result/ResultErrorExceptionTests.cs:line 79");
         errorStructure.Children.Should().BeEmpty();
+    }
+
+    private Exception ThrowException(string? errorMessage)
+    {
+        try
+        {
+            throw new Exception(errorMessage);
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
     }
 }

--- a/test/Futurum.Core.Tests/Result/ResultErrorKeyNotFoundTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorKeyNotFoundTests.cs
@@ -11,6 +11,19 @@ namespace Futurum.Core.Tests.Result;
 public class ResultErrorKeyNotFoundTests
 {
     [Fact]
+    public void ToErrorStringSafe()
+    {
+        var key = Guid.NewGuid().ToString();
+        var sourceDescription = Guid.NewGuid().ToString();
+
+        var resultError = ResultErrorKeyNotFound.Create(key, sourceDescription);
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be($"Unable to find key : '{key}' in source : '{sourceDescription}'");
+    }
+
+    [Fact]
     public void ToErrorString()
     {
         var key = Guid.NewGuid().ToString();
@@ -21,6 +34,20 @@ public class ResultErrorKeyNotFoundTests
         var errorString = resultError.ToErrorString(",");
 
         errorString.Should().Be($"Unable to find key : '{key}' in source : '{sourceDescription}'");
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var key = Guid.NewGuid().ToString();
+        var sourceDescription = Guid.NewGuid().ToString();
+
+        var resultError = ResultErrorKeyNotFound.Create(key, sourceDescription);
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        errorStructure.Message.Should().Be($"Unable to find key : '{key}' in source : '{sourceDescription}'");
+        errorStructure.Children.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Futurum.Core.Tests/Result/ResultErrorMessageTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorMessageTests.cs
@@ -11,6 +11,18 @@ namespace Futurum.Core.Tests.Result;
 public class ResultErrorMessageTests
 {
     [Fact]
+    public void ToErrorStringSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultError = errorMessage.ToResultError();
+
+        var errorString = resultError.ToErrorStringSafe(",");
+
+        errorString.Should().Be(errorMessage);
+    }
+
+    [Fact]
     public void ToErrorString()
     {
         var errorMessage = Guid.NewGuid().ToString();
@@ -20,6 +32,19 @@ public class ResultErrorMessageTests
         var errorString = resultError.ToErrorString(",");
 
         errorString.Should().Be(errorMessage);
+    }
+
+    [Fact]
+    public void ToErrorStructureSafe()
+    {
+        var errorMessage = Guid.NewGuid().ToString();
+
+        var resultError = errorMessage.ToResultError();
+
+        var errorStructure = resultError.ToErrorStructureSafe();
+
+        errorStructure.Message.Should().Be(errorMessage);
+        errorStructure.Children.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Futurum.Core.Tests/Result/ResultErrorStringExtensionsTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorStringExtensionsTests.cs
@@ -23,11 +23,17 @@ public class ResultErrorStringExtensionsTests
                 _message = message;
             }
 
-            public string GetErrorString() =>
+            public string GetErrorStringSafe() =>
                 _message;
 
+            public string GetErrorString() =>
+                GetErrorStringSafe();
+
+            public ResultErrorStructure GetErrorStructureSafe() =>
+                throw new InvalidOperationException($"'{nameof(GetErrorStructureSafe)}' method should not be called here.");
+
             public ResultErrorStructure GetErrorStructure() =>
-                throw new InvalidOperationException($"'{nameof(GetErrorStructure)}' method should not be called here.");
+                GetErrorStructureSafe();
         }
 
         private class TestCompositeResultError : IResultErrorComposite
@@ -39,11 +45,17 @@ public class ResultErrorStringExtensionsTests
                 _message = message;
             }
 
-            public string GetErrorString(string seperator) =>
+            public string GetErrorStringSafe(string seperator) =>
                 _message;
 
+            public string GetErrorString(string seperator) =>
+                GetErrorStringSafe(seperator);
+
+            public ResultErrorStructure GetErrorStructureSafe() =>
+                throw new InvalidOperationException($"'{nameof(GetErrorStructureSafe)}' method should not be called here.");
+
             public ResultErrorStructure GetErrorStructure() =>
-                throw new InvalidOperationException($"'{nameof(GetErrorStructure)}' method should not be called here.");
+                GetErrorStructureSafe();
 
             public Option<IResultErrorNonComposite> Parent { get; }
             public IEnumerable<IResultError> Children { get; }
@@ -51,12 +63,51 @@ public class ResultErrorStringExtensionsTests
 
         private class TestUnknownResultError : IResultError
         {
+            public ResultErrorStructure GetErrorStructureSafe() =>
+                throw new InvalidOperationException($"'{nameof(GetErrorStructureSafe)}' method should not be called here.");
+
             public ResultErrorStructure GetErrorStructure() =>
-                throw new InvalidOperationException($"'{nameof(GetErrorStructure)}' method should not be called here.");
+                GetErrorStructureSafe();
         }
 
         [Fact]
-        public void when_IResultErrorNonComposite_return_ResultError_GetErrorString()
+        public void when_IResultErrorNonComposite_return_ResultError_ToErrorStringSafe_Without_Seperator()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestNonCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe();
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+        
+        [Fact]
+        public void when_IResultErrorNonComposite_return_ResultError_ToErrorStringSafe()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestNonCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe(",");
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void when_IResultErrorNonComposite_return_ResultError_ToErrorString_Without_Seperator()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestNonCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorString();
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void when_IResultErrorNonComposite_return_ResultError_ToErrorString()
         {
             var errorMessage = Guid.NewGuid().ToString();
 
@@ -68,7 +119,43 @@ public class ResultErrorStringExtensionsTests
         }
 
         [Fact]
-        public void when_IResultErrorComposite_return_ResultError_GetErrorString()
+        public void when_IResultErrorComposite_return_ResultError_ToErrorStringSafe_Without_Seperator()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe();
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void when_IResultErrorComposite_return_ResultError_ToErrorStringSafe()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe(",");
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void when_IResultErrorComposite_return_ResultError_ToErrorString_Without_Seperator()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestCompositeResultError(errorMessage);
+
+            var formattedErrorMessage = resultError.ToErrorString();
+
+            formattedErrorMessage.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void when_IResultErrorComposite_return_ResultError_ToErrorString()
         {
             var errorMessage = Guid.NewGuid().ToString();
 
@@ -80,7 +167,37 @@ public class ResultErrorStringExtensionsTests
         }
 
         [Fact]
-        public void when_Unknown_IResultError_return_UnknownResultErrorOfType_GetErrorString()
+        public void when_Unknown_IResultError_return_UnknownResultErrorOfType_ToErrorStringSafe_Without_Seperator()
+        {
+            IResultError resultError = new TestUnknownResultError();
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe();
+
+            formattedErrorMessage.Should().StartWith($"Unknown ResultError of type {typeof(TestUnknownResultError).FullName}");
+        }
+
+        [Fact]
+        public void when_Unknown_IResultError_return_UnknownResultErrorOfType_ToErrorStringSafe()
+        {
+            IResultError resultError = new TestUnknownResultError();
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe(",");
+
+            formattedErrorMessage.Should().StartWith($"Unknown ResultError of type {typeof(TestUnknownResultError).FullName}");
+        }
+
+        [Fact]
+        public void when_Unknown_IResultError_return_UnknownResultErrorOfType_ToErrorString_Without_Seperator()
+        {
+            IResultError resultError = new TestUnknownResultError();
+
+            var formattedErrorMessage = resultError.ToErrorString();
+
+            formattedErrorMessage.Should().StartWith($"Unknown ResultError of type {typeof(TestUnknownResultError).FullName}");
+        }
+
+        [Fact]
+        public void when_Unknown_IResultError_return_UnknownResultErrorOfType_ToErrorString()
         {
             IResultError resultError = new TestUnknownResultError();
 
@@ -90,7 +207,37 @@ public class ResultErrorStringExtensionsTests
         }
 
         [Fact]
-        public void when_Null_return_empty_string()
+        public void when_Null_return_empty_string_ToErrorStringSafe_Without_Seperator()
+        {
+            IResultError resultError = null;
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe();
+
+            formattedErrorMessage.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void when_Null_return_empty_string_ToErrorStringSafe()
+        {
+            IResultError resultError = null;
+
+            var formattedErrorMessage = resultError.ToErrorStringSafe(",");
+
+            formattedErrorMessage.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void when_Null_return_empty_string_ToErrorString_Without_Seperator()
+        {
+            IResultError resultError = null;
+
+            var formattedErrorMessage = resultError.ToErrorString();
+
+            formattedErrorMessage.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void when_Null_return_empty_string_ToErrorString()
         {
             IResultError resultError = null;
 

--- a/test/Futurum.Core.Tests/Result/ResultErrorStructureExtensionsTests.cs
+++ b/test/Futurum.Core.Tests/Result/ResultErrorStructureExtensionsTests.cs
@@ -22,15 +22,34 @@ public class ResultErrorStructureExtensionsTests
                 _message = message;
             }
 
+            public string GetErrorStringSafe() =>
+                throw new InvalidOperationException($"'{nameof(GetErrorStringSafe)}' method should not be called here.");
+
             public string GetErrorString() =>
-                throw new InvalidOperationException($"'{nameof(GetErrorString)}' method should not be called here.");
+                GetErrorStringSafe();
+
+            public ResultErrorStructure GetErrorStructureSafe() =>
+                _message.ToResultErrorStructure();
 
             public ResultErrorStructure GetErrorStructure() =>
-                _message.ToResultErrorStructure();
+                GetErrorStructureSafe();
         }
 
         [Fact]
-        public void when_not_Null_return_ResultError_GetErrorStructure()
+        public void when_not_Null_return_ResultError_ToErrorStructureSafe()
+        {
+            var errorMessage = Guid.NewGuid().ToString();
+
+            IResultError resultError = new TestResultError(errorMessage);
+
+            var errorStructure = resultError.ToErrorStructureSafe();
+
+            errorStructure.Message.Should().Be(errorMessage);
+            errorStructure.Children.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void when_not_Null_return_ResultError_ToErrorStructure()
         {
             var errorMessage = Guid.NewGuid().ToString();
 
@@ -43,7 +62,18 @@ public class ResultErrorStructureExtensionsTests
         }
 
         [Fact]
-        public void when_Null_return_empty_string()
+        public void when_Null_return_empty_string_ToErrorStructureSafe()
+        {
+            IResultError resultError = null;
+
+            var errorStructure = resultError.ToErrorStructureSafe();
+
+            errorStructure.Message.Should().BeEmpty();
+            errorStructure.Children.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void when_Null_return_empty_string_ToErrorStructure()
         {
             IResultError resultError = null;
 
@@ -80,7 +110,7 @@ public class ResultErrorStructureExtensionsTests
         public void only_children()
         {
             var children = Enumerable.Range(0, 10)
-                                         .Select(x => x.ToString().ToResultError().ToErrorStructure());
+                                         .Select(x => x.ToString().ToResultError().ToErrorStructureSafe());
             
             var resultErrorStructure = ResultErrorStructureExtensions.ToResultErrorStructure(children);
 
@@ -94,7 +124,7 @@ public class ResultErrorStructureExtensionsTests
             var errorMessage = Guid.NewGuid().ToString();
 
             var children = Enumerable.Range(0, 10)
-                                         .Select(x => x.ToString().ToResultError().ToErrorStructure());
+                                         .Select(x => x.ToString().ToResultError().ToErrorStructureSafe());
             
             var resultErrorStructure = ResultErrorStructureExtensions.ToResultErrorStructure(errorMessage, children);
 

--- a/test/Futurum.Core.Tests/Result/ResultTests.DoWhenFailure.cs
+++ b/test/Futurum.Core.Tests/Result/ResultTests.DoWhenFailure.cs
@@ -39,7 +39,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         returnedResult.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -76,7 +76,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         resultOutput.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -186,7 +186,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         returnedResult.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -230,7 +230,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         resultOutput.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -366,7 +366,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         returnedResult.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -403,7 +403,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         resultOutput.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -513,7 +513,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         returnedResult.ShouldBeFailureWithError(ErrorMessage);
                     }
 
@@ -557,7 +557,7 @@ public class ResultDoWhenFailureTests
                         });
 
                         wasCalled.Should().BeTrue();
-                        passedResultError.ToErrorString().Should().Be(ErrorMessage);
+                        passedResultError.ToErrorStringSafe().Should().Be(ErrorMessage);
                         resultOutput.ShouldBeFailureWithError(ErrorMessage);
                     }
 

--- a/test/Futurum.Core.Tests/Result/ResultTests.ThenTry.cs
+++ b/test/Futurum.Core.Tests/Result/ResultTests.ThenTry.cs
@@ -64,7 +64,7 @@ public class ResultThenTryTests
                                                            },
                                                            () => ErrorMessage3);
 
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -132,7 +132,7 @@ public class ResultThenTryTests
                                                            () => ErrorMessage3);
 
                     passedValue.Should().Be(inputValue);
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -204,7 +204,7 @@ public class ResultThenTryTests
                                                            _ => ErrorMessage3);
 
                     passedValue.Should().Be(inputValue);
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -278,7 +278,7 @@ public class ResultThenTryTests
                                                                       },
                                                                       () => ErrorMessage3);
 
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -348,7 +348,7 @@ public class ResultThenTryTests
                                                                       () => ErrorMessage3);
 
                     passedValue.Should().Be(inputValue);
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -425,7 +425,7 @@ public class ResultThenTryTests
                                                                       },
                                                                       () => ErrorMessage3);
 
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -493,7 +493,7 @@ public class ResultThenTryTests
                                                                       () => ErrorMessage3);
 
                     passedValue.Should().Be(inputValue);
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -569,7 +569,7 @@ public class ResultThenTryTests
                                                                       },
                                                                       () => ErrorMessage3);
 
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -639,7 +639,7 @@ public class ResultThenTryTests
                                                                       () => ErrorMessage3);
 
                     passedValue.Should().Be(inputValue);
-                    resultOutput.ShouldBeFailureWithError($"{ErrorMessage3};{ErrorMessage1}");
+                    resultOutput.ShouldBeFailureWithErrorSafe($"{ErrorMessage3};{ErrorMessage1}");
                 }
 
                 [Fact]

--- a/test/Futurum.Core.Tests/Result/ResultTests.Try.cs
+++ b/test/Futurum.Core.Tests/Result/ResultTests.Try.cs
@@ -25,7 +25,7 @@ public class ResultTryTests
                     Action action = () => throw new Exception(ErrorMessage1);
                     var result = Core.Result.Result.Try(action, ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -46,7 +46,7 @@ public class ResultTryTests
                     Action action = () => throw new Exception(ErrorMessage1);
                     var result = Core.Result.Result.Try(action, () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -67,7 +67,7 @@ public class ResultTryTests
                     Action action = () => throw new Exception(ErrorMessage1);
                     var result = Core.Result.Result.Try(action, ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -88,7 +88,7 @@ public class ResultTryTests
                     Action action = () => throw new Exception(ErrorMessage1);
                     var result = Core.Result.Result.Try(action, () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -119,7 +119,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -149,7 +149,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -179,7 +179,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -209,7 +209,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -240,7 +240,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -275,7 +275,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -310,7 +310,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -345,7 +345,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -385,7 +385,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -424,7 +424,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -463,7 +463,7 @@ public class ResultTryTests
                                                         },
                                                         ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -502,7 +502,7 @@ public class ResultTryTests
                                                         },
                                                         () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -540,7 +540,7 @@ public class ResultTryTests
                     Func<Task> func = () => throw new Exception(ErrorMessage1);
                     var result = await Core.Result.Result.TryAsync(func, ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -561,7 +561,7 @@ public class ResultTryTests
                     Func<Task> func = () => throw new Exception(ErrorMessage1);
                     var result = await Core.Result.Result.TryAsync(func, () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -582,7 +582,7 @@ public class ResultTryTests
                     Func<Task> func = () => throw new Exception(ErrorMessage1);
                     var result = await Core.Result.Result.TryAsync(func, ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -603,7 +603,7 @@ public class ResultTryTests
                     Func<Task> func = () => throw new Exception(ErrorMessage1);
                     var result = await Core.Result.Result.TryAsync(func, () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -634,7 +634,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -664,7 +664,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -694,7 +694,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -724,7 +724,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -757,7 +757,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -787,7 +787,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -817,7 +817,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -847,7 +847,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -878,7 +878,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -913,7 +913,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -948,7 +948,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -983,7 +983,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -1023,7 +1023,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -1062,7 +1062,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2);
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -1101,7 +1101,7 @@ public class ResultTryTests
                                                                    },
                                                                    ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]
@@ -1140,7 +1140,7 @@ public class ResultTryTests
                                                                    },
                                                                    () => ErrorMessage2.ToResultError());
 
-                    result.ShouldBeFailureWithError($"{ErrorMessage2};{ErrorMessage1}");
+                    result.ShouldBeFailureWithErrorSafe($"{ErrorMessage2};{ErrorMessage1}");
                 }
 
                 [Fact]


### PR DESCRIPTION
…cture()', to remove sensitive information e.g. StackTraces